### PR TITLE
Standardise use of <form elements

### DIFF
--- a/frontend/src/Institution/CreateInstitutionAliasPage/index.js
+++ b/frontend/src/Institution/CreateInstitutionAliasPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'primereact/button';
 import InputBox from "../../components/InputBox";
 import InstitutionSelector from "../../components/InstitutionSelector";
 const ttlib = require("ttlib");
@@ -36,7 +37,8 @@ class CreateInstitutionAliasPage extends React.Component {
         )
     }
 
-    save() {
+    save(event) {
+        event.preventDefault();
         ttlib.validation.objContainsFields(this.state, ["selectedInstitution", "alias"]).then(form => {
             ttlib.api.requestAPI(
                 `/institutions/${form.selectedInstitution.id}/alias`,
@@ -62,37 +64,38 @@ class CreateInstitutionAliasPage extends React.Component {
     render() {
         return(
             <div>
-                {
-                    this.fields.map(field => (
-                        <InputBox
-                            id={field.id}
-                            value={this.state[field.id]}
-                            cb={(dict) => this.setState(dict)}
-                            errors={this.state.errors}
-                            type={field.type}
-                            label={field.label}
-                            options={field.options}
-                        />
-                    ))
-                }
-                {
-                    this.state.selectedInstitution ?
-                        <div className="alert alert-warning mt-2">
-                            Current Aliases for {this.state.selectedInstitution.name}:
-                            {
-                                this.state.selectedInstitution.InstitutionAliases.length === 0 ? "None" : ""
-                            }
-                            <ul>
-                                {this.state.selectedInstitution.InstitutionAliases.map(aliasObj => (
-                                    <li>{aliasObj.alias}</li>
-                                ))}
-                            </ul>
-                            <p>Before you add a new alias, please double check that it's not on this list already!</p>
-                        </div>
-                        : ""
-                }
-                <br/>
-                <button onClick={this.save} className="btn btn-success btn-block mt-2">Save</button>
+                <form onSubmit={this.save}>
+                    {
+                        this.fields.map(field => (
+                            <InputBox
+                                id={field.id}
+                                value={this.state[field.id]}
+                                cb={(dict) => this.setState(dict)}
+                                errors={this.state.errors}
+                                type={field.type}
+                                label={field.label}
+                                options={field.options}
+                            />
+                        ))
+                    }
+                    {
+                        this.state.selectedInstitution ?
+                            <div className="alert alert-warning mt-2">
+                                Current Aliases for {this.state.selectedInstitution.name}:
+                                {
+                                    this.state.selectedInstitution.InstitutionAliases.length === 0 ? "None" : ""
+                                }
+                                <ul>
+                                    {this.state.selectedInstitution.InstitutionAliases.map(aliasObj => (
+                                        <li>{aliasObj.alias}</li>
+                                    ))}
+                                </ul>
+                                <p>Before you add a new alias, please double check that it's not on this list already!</p>
+                            </div>
+                            : ""
+                    }
+                    <Button label="Save" className="btn btn-success btn-block mt-2" />
+                </form>
             </div>
         );
     }

--- a/frontend/src/Institution/CreateInstitutionPage/index.js
+++ b/frontend/src/Institution/CreateInstitutionPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'primereact/button';
 import InputBox from "../../components/InputBox";
 import Fuse from 'fuse.js';
 const ttlib = require("ttlib");
@@ -61,7 +62,8 @@ class CreateInstitutionPage extends React.Component {
         }
     }
 
-    save() {
+    save(event) {
+        event.preventDefault();
         ttlib.api.requestAPI(
             `/institutions/create`,
             `POST`,
@@ -96,21 +98,22 @@ class CreateInstitutionPage extends React.Component {
                         :
                         ""
                 }
-                {
-                    this.fields.map(field => (
-                        <InputBox
-                            id={field.id}
-                            value={this.state[field.id]}
-                            cb={(dict) => this.changeState(dict)}
-                            errors={this.state.errors}
-                            type={field.type}
-                            label={field.label}
-                            tooltip={field.tooltip}
-                        />
-                    ))
-                }
-                <br/>
-                <button onClick={this.save} className="btn btn-success btn-block">Save</button>
+                <form onSubmit={this.save}>
+                    {
+                        this.fields.map(field => (
+                            <InputBox
+                                id={field.id}
+                                value={this.state[field.id]}
+                                cb={(dict) => this.changeState(dict)}
+                                errors={this.state.errors}
+                                type={field.type}
+                                label={field.label}
+                                tooltip={field.tooltip}
+                            />
+                        ))
+                    }
+                    <Button label="Save" className="btn btn-success btn-block" />
+                </form>
             </div>
         );
     }

--- a/frontend/src/LoginPage/index.js
+++ b/frontend/src/LoginPage/index.js
@@ -20,7 +20,8 @@ class LoginPage extends React.Component {
         this.login = this.login.bind(this);
     }
 
-    login() {
+    login(event) {
+        event.preventDefault();
         let validation = true;
         let errors = {};
         // This should probably be refactored to be more dynamic.
@@ -91,10 +92,9 @@ class LoginPage extends React.Component {
                                     type="password"
                                     errors={this.state.errors}
                                 />
+                                <Button label="Login" className="p-button-raised p-button-success p-mt-4" type="submit" />
+                                <Button label="Forgot Password" className="p-button-raised p-button-secondary p-ml-4" />
                             </form>
-
-                            <Button label="Login" className="p-button-raised p-button-success p-mt-4" onClick={this.login} />
-                            <Button label="Forgot Password" className="p-button-raised p-button-secondary p-ml-4" />
                         </Card>
                     </div>
                 </div>

--- a/frontend/src/NavBar/index.js
+++ b/frontend/src/NavBar/index.js
@@ -103,7 +103,7 @@ class NavBar extends React.Component {
                     </ul>
                     <form className="form-inline my-2 my-lg-0">
                         <input className="form-control mr-sm-2" type="search" placeholder="Tournament Search"/>
-                            <button className="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+                        <button className="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
                     </form>
                 </div>
             </nav>

--- a/frontend/src/RegisterPage/index.js
+++ b/frontend/src/RegisterPage/index.js
@@ -27,7 +27,8 @@ class RegisterPage extends React.Component {
         this.register = this.register.bind(this);
     }
 
-    register() {
+    register(event) {
+        event.preventDefault();
         let validation = true;
         let errors = {};
         // This should probably be refactored to be more dynamic.
@@ -98,9 +99,8 @@ class RegisterPage extends React.Component {
                                         />
                                     ))
                                 }
+                                <Button label="Register" className="p-button-raised p-button-success p-mt-4" />
                             </form>
-
-                            <Button label="Register" className="p-button-raised p-button-success p-mt-4" onClick={this.register} />
                         </Card>
                     </div>
                 </div>

--- a/frontend/src/Tournament/CreatePlaceholderModelPage/index.js
+++ b/frontend/src/Tournament/CreatePlaceholderModelPage/index.js
@@ -56,7 +56,8 @@ class CreatePlaceholderModelPage extends React.Component {
         }
     }
 
-    submit() {
+    submit(event) {
+        event.preventDefault();
         ttlib.validation.objContainsFields(this.state, this.fields.filter(f => f.required).map(f => f.id)).then(() => {
             let formObj = {};
             this.fields.forEach(field => {
@@ -95,34 +96,36 @@ class CreatePlaceholderModelPage extends React.Component {
                     <div className="p-col-8">
                         <TournamentToolBar slug={this.props.match.params.slug}/>
                         <Card>
-                            <div className="display-4 text-center">Create{this.state.model !== "venues" ? " Placeholder " : " "}{this.state.model === "teams" ? "Team" : this.state.model === "venues" ? "Venue" : "Adjudicator"}</div>
-                            {
-                                this.state.model === "teams" ?
-                                    <div className="alert alert-info text-center">This tool is only for creating <b>break ineligible</b> swing/placeholder teams required to make the tournament team count divisible by 4. These teams will be exempted from institutional clash and will not be included in the break calculations.</div>
-                                    :
-                                    this.state.model === "adjudicators" ?
-                                    <div className="alert alert-info text-center">This tool is only for creating <b>break ineligible</b> placeholder adjudicators for a rapid stand in adjudicator. They will not be able to submit e-ballots, submit feedback, receive feedback or be marked as breaking.</div>
-                                    : ""
-                            }
-                            <hr/>
-                            {
-                                this.fields.map(field => (
-                                    <InputBox
-                                        id={field.id}
-                                        value={this.state[field.id]}
-                                        cb={(dict) => this.setState(dict)}
-                                        errors={this.state.errors}
-                                        type={field.type}
-                                        label={field.label}
-                                        tooltip={field.tooltip}
-                                        options={field.options}
-                                        multiple={true}
-                                        min={field.min}
-                                        max={field.max}
-                                    />
-                                ))
-                            }
-                            <Button onClick={this.submit} className="btn btn-block p-button-success p-mt-2" label="Create"/>
+                            <form onSubmit={this.submit}>
+                                <div className="display-4 text-center">Create{this.state.model !== "venues" ? " Placeholder " : " "}{this.state.model === "teams" ? "Team" : this.state.model === "venues" ? "Venue" : "Adjudicator"}</div>
+                                {
+                                    this.state.model === "teams" ?
+                                        <div className="alert alert-info text-center">This tool is only for creating <b>break ineligible</b> swing/placeholder teams required to make the tournament team count divisible by 4. These teams will be exempted from institutional clash and will not be included in the break calculations.</div>
+                                        :
+                                        this.state.model === "adjudicators" ?
+                                        <div className="alert alert-info text-center">This tool is only for creating <b>break ineligible</b> placeholder adjudicators for a rapid stand in adjudicator. They will not be able to submit e-ballots, submit feedback, receive feedback or be marked as breaking.</div>
+                                        : ""
+                                }
+                                <hr/>
+                                {
+                                    this.fields.map(field => (
+                                        <InputBox
+                                            id={field.id}
+                                            value={this.state[field.id]}
+                                            cb={(dict) => this.setState(dict)}
+                                            errors={this.state.errors}
+                                            type={field.type}
+                                            label={field.label}
+                                            tooltip={field.tooltip}
+                                            options={field.options}
+                                            multiple={true}
+                                            min={field.min}
+                                            max={field.max}
+                                        />
+                                    ))
+                                }
+                                <Button className="btn btn-block p-button-success p-mt-2" label="Create"/>
+                            </form>
                         </Card>
                     </div>
                 </div>

--- a/frontend/src/Tournament/CreateTournamentPage/index.js
+++ b/frontend/src/Tournament/CreateTournamentPage/index.js
@@ -60,7 +60,8 @@ class CreateTournamentPage extends React.Component {
         });
     }
 
-    submit() {
+    submit(event) {
+        event.preventDefault();
         ttlib.validation.objContainsFields(this.state, this.fields.filter(f => f.required).map(f => f.id)).then(postForm => {
             ttlib.api.requestAPI(
                 `/tournaments/create`,
@@ -101,52 +102,54 @@ class CreateTournamentPage extends React.Component {
                 <div className="p-grid p-justify-center p-align-center p-mt-5">
                     <div className="p-col-8">
                         <Card>
-                            <div className="display-4 text-center">New Tournament</div>
-                            <hr/>
-                            {
-                                this.fields.map(field => (
-                                    <InputBox
-                                        id={field.id}
-                                        value={this.state[field.id]}
-                                        cb={(dict) => this.setState(dict)}
-                                        errors={this.state.errors}
-                                        type={field.type}
-                                        label={field.label}
-                                        tooltip={field.tooltip}
-                                        options={field.options}
-                                        multiple={true}
-                                        min={field.min}
-                                        max={field.max}
-                                    />
-                                ))
-                            }
-                            <hr/>
-                            <div className="display-5 mb-3">Tournament Settings</div>
-                            {
-                                this.settings.map((setting) => {
-                                    return (
-                                        <div key={`div-${setting.id}`} className="p-field-checkbox">
-                                            <Checkbox
-                                                inputId={setting.id}
-                                                name={setting.id}
-                                                checked={this.state.settings[setting.id]}
-                                                onChange={
-                                                    (e) => {
-                                                        let curSet = this.state.settings;
-                                                        curSet[e.target.name] = e.checked;
-                                                        this.setState({
-                                                                settings: curSet
-                                                            }
-                                                        )
+                            <form onSubmit={this.submit}>
+                                <div className="display-4 text-center">New Tournament</div>
+                                <hr/>
+                                {
+                                    this.fields.map(field => (
+                                        <InputBox
+                                            id={field.id}
+                                            value={this.state[field.id]}
+                                            cb={(dict) => this.setState(dict)}
+                                            errors={this.state.errors}
+                                            type={field.type}
+                                            label={field.label}
+                                            tooltip={field.tooltip}
+                                            options={field.options}
+                                            multiple={true}
+                                            min={field.min}
+                                            max={field.max}
+                                        />
+                                    ))
+                                }
+                                <hr/>
+                                <div className="display-5 mb-3">Tournament Settings</div>
+                                {
+                                    this.settings.map((setting) => {
+                                        return (
+                                            <div key={`div-${setting.id}`} className="p-field-checkbox">
+                                                <Checkbox
+                                                    inputId={setting.id}
+                                                    name={setting.id}
+                                                    checked={this.state.settings[setting.id]}
+                                                    onChange={
+                                                        (e) => {
+                                                            let curSet = this.state.settings;
+                                                            curSet[e.target.name] = e.checked;
+                                                            this.setState({
+                                                                    settings: curSet
+                                                                }
+                                                            )
+                                                        }
                                                     }
-                                                }
-                                            />
-                                            <label htmlFor={`label-${setting.id}`}>{setting.label} - <small>{setting.description}</small></label>
-                                        </div>
-                                    )
-                                })
-                            }
-                            <Button onClick={this.submit} className="btn btn-block p-button-success" label="Create"/>
+                                                />
+                                                <label htmlFor={`label-${setting.id}`}>{setting.label} - <small>{setting.description}</small></label>
+                                            </div>
+                                        )
+                                    })
+                                }
+                                <Button className="btn btn-block p-button-success" label="Create"/>
+                            </form>
                         </Card>
                     </div>
                 </div>

--- a/frontend/src/Tournament/RoundViewPage/MotionDialog/index.js
+++ b/frontend/src/Tournament/RoundViewPage/MotionDialog/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'primereact/button';
 import {Dialog} from "primereact/dialog";
 import InputBox from "../../../components/InputBox";
 const ttlib = require("ttlib");
@@ -21,7 +22,8 @@ class MotionDialog extends React.Component {
         this.submit = this.submit.bind(this);
     }
 
-    submit() {
+    submit(event) {
+        event.preventDefault();
         ttlib.validation.objContainsFields(this.state, ['motion']).then(() => {
             let postForm = {
                 motion: this.state.motion
@@ -47,31 +49,27 @@ class MotionDialog extends React.Component {
                 }
             })
         })
+        this.props.hide()
     }
 
     render() {
         return(
             <Dialog header={`${this.props.round.title} - Motion & Info Slide`} visible={this.props.visible} onHide={this.props.hide}>
-                {
-                    this.fields.map(field => (
-                        <InputBox
-                            id={field.id}
-                            label={field.label}
-                            cb={(dict) => this.setState(dict)}
-                            value={this.state[field.id]}
-                            type={field.type || "text"}
-                            errors={this.state.errors}
-                        />
-                    ))
-                }
-                <button className="btn btn-block btn-success"
-                        onClick={() => {
-                                this.submit();
-                                this.props.hide();
-                            }
-                        }>
-                    Save
-                </button>
+                <form onSubmit={this.submit}>
+                    {
+                        this.fields.map(field => (
+                            <InputBox
+                                id={field.id}
+                                label={field.label}
+                                cb={(dict) => this.setState(dict)}
+                                value={this.state[field.id]}
+                                type={field.type || "text"}
+                                errors={this.state.errors}
+                            />
+                        ))
+                    }
+                    <Button label="Save" className="btn btn-block btn-success" />
+                </form>
             </Dialog>
         )
     }

--- a/frontend/src/UserProfile/InstitutionMembershipForm/index.js
+++ b/frontend/src/UserProfile/InstitutionMembershipForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'primereact/button';
 import InputBox from "../../components/InputBox";
 const ttlib = require("ttlib");
 
@@ -40,7 +41,8 @@ class InstitutionMembershipForm extends React.Component {
         )
     }
 
-    submit() {
+    submit(event) {
+        event.preventDefault();
         console.log(this.state);
         ttlib.validation.objContainsFields(this.state, ["selectedInstitution"]).then(postForm => {
             ttlib.api.requestAPI(
@@ -68,22 +70,23 @@ class InstitutionMembershipForm extends React.Component {
     render() {
         return(
             <div>
-                {
-                    this.fields.map(field => (
-                        <InputBox
-                            id={field.id}
-                            value={this.state[field.id]}
-                            cb={(dict) => this.setState(dict)}
-                            errors={this.state.errors}
-                            type={field.type}
-                            label={field.label}
-                            options={field.options}
-                            time={field.time}
-                        />
-                    ))
-                }
-                <br/>
-                <button onClick={this.submit} className="btn btn-success btn-block mt-2">Save</button>
+                <form onSubmit={this.submit}>
+                    {
+                        this.fields.map(field => (
+                            <InputBox
+                                id={field.id}
+                                value={this.state[field.id]}
+                                cb={(dict) => this.setState(dict)}
+                                errors={this.state.errors}
+                                type={field.type}
+                                label={field.label}
+                                options={field.options}
+                                time={field.time}
+                            />
+                        ))
+                    }
+                    <Button label="Save" className="btn btn-success btn-block mt-2" />
+                </form>
             </div>
         )
     }

--- a/frontend/src/UserProfile/PersonalClashForm/index.js
+++ b/frontend/src/UserProfile/PersonalClashForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'primereact/button';
 import InputBox from "../../components/InputBox";
 import NavBar from "../../NavBar";
 import {Toast} from "primereact/toast";
@@ -40,7 +41,8 @@ class PersonalClashForm extends React.Component {
         )
     }
 
-    submit() {
+    submit(event) {
+        event.preventDefault();
         ttlib.validation.objContainsFields(this.state, ["selectedTarget", "type"]).then(postForm => {
             if (!this.state.selectedTarget.length === 1) {
                 this.setState({
@@ -78,33 +80,34 @@ class PersonalClashForm extends React.Component {
         return(
             <div>
                 <Toast ref={(ref) => this.toast = ref}/>
-                {
-                    this.fields.map(field => (
-                        <InputBox
-                            id={field.id}
-                            value={this.state[field.id]}
-                            cb={(dict) => this.setState(dict)}
-                            errors={this.state.errors}
-                            type={field.type}
-                            label={field.label}
-                            options={field.options}
-                        />
-                    ))
-                }
-                {
-                    this.state.type ?
-                        <div className="alert alert-info">
-                            {
-                                this.state.type === "soft" ?
-                                    <p>Soft Clash is clash which can be violated strictly when necessary to produce a draw with you in it and may be pre-emptively displayed when the adjudication core are producing the draw.</p>
-                                    :
-                                    <p>Hard Clash is the most severe form of clash and will not be revealed in a draw's generation unless it is violated. You would rather not take part in the round than face a situation where your hard clash cannot be violated.</p>
-                            }
-                        </div>
-                        : ""
-                }
-                <br/>
-                <button onClick={this.submit} className="btn btn-success btn-block mt-2">Save</button>
+                <form onSubmit={this.submit}>
+                    {
+                        this.fields.map(field => (
+                            <InputBox
+                                id={field.id}
+                                value={this.state[field.id]}
+                                cb={(dict) => this.setState(dict)}
+                                errors={this.state.errors}
+                                type={field.type}
+                                label={field.label}
+                                options={field.options}
+                            />
+                        ))
+                    }
+                    {
+                        this.state.type ?
+                            <div className="alert alert-info">
+                                {
+                                    this.state.type === "soft" ?
+                                        <p>Soft Clash is clash which can be violated strictly when necessary to produce a draw with you in it and may be pre-emptively displayed when the adjudication core are producing the draw.</p>
+                                        :
+                                        <p>Hard Clash is the most severe form of clash and will not be revealed in a draw's generation unless it is violated. You would rather not take part in the round than face a situation where your hard clash cannot be violated.</p>
+                                }
+                            </div>
+                            : ""
+                    }
+                    <Button label="Save" className="btn btn-success btn-block mt-2"/>
+                </form>
             </div>
         )
     }


### PR DESCRIPTION
For semantics, link all elements of forms within form elements, including the submit button. This also helps with accessibility and future power-users using keyboard shortcuts.

To prevent the page from POSTing and thus losing state, the onSubmit suppresses the normal form behaviour.